### PR TITLE
Feat: Supabase init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ Frontend/windows/flutter/generated_plugin_registrant.h
 Frontend/windows/flutter/generated_plugins.cmake
 .vscode/extensions.json
 .vscode/settings.json
+.vscode/launch.json
 /supabase
 Frontend/pubspec.lock
 gitflow.png

--- a/Frontend/lib/constants.dart
+++ b/Frontend/lib/constants.dart
@@ -1,0 +1,11 @@
+abstract class Constants {
+  static const String supabaseUrl = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: '',
+  );
+
+  static const String supabaseAnonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+    defaultValue: '',
+  );
+}

--- a/Frontend/lib/main.dart
+++ b/Frontend/lib/main.dart
@@ -1,8 +1,15 @@
+import 'package:darts_application/constants.dart';
 import 'package:darts_application/router.dart';
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 void main() {
+  Supabase.initialize(
+    url: Constants.supabaseUrl,
+    anonKey: Constants.supabaseAnonKey,
+  );
   runApp(const MyApp());
+
 }
 
 class MyApp extends StatelessWidget {


### PR DESCRIPTION
Made an abstract constants class that loads environment variables for use in different Supabase environments.
With the CLI u can define env variables using dart-define. An example of this for vs code is the JSON below u can be put in the .vscode/launch.json of your workspace.
```json
{
    "version": "0.2.0",
    "configurations": [
      {
        "name": "Production",
        "request": "launch",
        "type": "dart",
        "program": "Frontend/lib/main.dart",
        "args": [
          "--dart-define=SUPABASE_URL=url",
          "--dart-define=SUPABASE_ANON_KEY=key"
        ]
      },
      {
        "name": "Dev",
        "request": "launch",
        "type": "dart",
        "program": "Frontend/lib/main.dart",
        "args": [
          "--dart-define=SUPABASE_URL=http://127.0.0.1:54321",
          "--dart-define=SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0"
        ]
      }
    ]
  }
 ```
