### PR TITLE
Fix: Users get redirected when they first load in the app when already authenticated

### DIFF
--- a/Frontend/lib/features/auth/auth_notifier.dart
+++ b/Frontend/lib/features/auth/auth_notifier.dart
@@ -10,7 +10,8 @@ class AuthNotifier extends ChangeNotifier {
       final AuthChangeEvent event = data.event;
       if (event == AuthChangeEvent.signedIn ||
           event == AuthChangeEvent.signedOut ||
-          event == AuthChangeEvent.userDeleted) {
+          event == AuthChangeEvent.userDeleted ||
+          event == AuthChangeEvent.initialSession) {
         notifyListeners();
       }
     });


### PR DESCRIPTION
Redirects now work on the Supabase initialSession.

Fixes #8 